### PR TITLE
Singleton methods and singleton classes

### DIFF
--- a/interview/rails.md
+++ b/interview/rails.md
@@ -65,43 +65,6 @@
       Подробнее [тут](http://rusrails.ru/active-record-query-interface#scopes)
     </details>
     
-1. Что такое синглтон метод?
-
-    <details>
-      <summary>Ответ</summary>
-      Синглтон метод (singleton method) - метод, принадлежащий только одному объекту (экземпляру класса или классу). Другие экземпляры этого же класса (или классы) к этому методу доступа не имеют.
-           
-      ```rb
-      class A
-        def say_something
-          "Something"
-        end
-      end
-      
-      foo = A.new
-      
-      bar = A.new
-      
-      # присваиваем объекту 'foo' отдельный метод (синглтон) 
-      def foo.laugh
-        "HAHAHAHA!"
-      end
-      
-      foo.say_something
-      => "Something"
-      
-      bar.say_something
-      => "Something"
-      
-      foo.laugh
-      => "HAHAHAHA!"
-      
-      bar.laugh
-      => NoMethodError (undefined method `laugh' for #<A:0x0000559bd8412138>)
-      ```
-      Подробнее [тут](https://habr.com/ru/post/143990/)
-    </details>
-
 1. Что такое ActiveJob? Когда его использовать?
     <details>
       <summary>Ответ</summary>

--- a/interview/rails.md
+++ b/interview/rails.md
@@ -154,7 +154,7 @@
 
       Что касается JSON, то Active Model также предоставляет модуль `ActiveModel::Serializers::JSON` для сериализации/десериализации JSON.
 
-      [Статья в wiki о сериализации](https://ru.wikipedia.org/wiki/%D0%A1%D0%B5%D1%80%D0%B8%D0%B0%D0%BB%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F)
+      [Статья в wiki о сериализации](https://ru.wikipedia.org/wiki/Сериализация)
       
       [Rails docs ru](http://rusrails.ru/active-model-basics)
       

--- a/interview/ruby.md
+++ b/interview/ruby.md
@@ -395,6 +395,58 @@
       Так же можно сообщить что все методы будут `self`, делается с помощью `class << self`.
     </details>
 
+1. Что такое синглтон-методы и синглтон-классы?
+
+    <details>
+      <summary>Ответ</summary>
+      Синглтон-метод — метод, который может принадлежать только одному объекту. Это даёт возможность добавлять уникальное поведение отдельным объектам.
+
+      ```rb
+      cat = Animal.new
+      dog = Animal.new
+
+      def dog.barking
+        'WOOF! WOOF!'
+      end
+
+      dog.barking
+      # => "WOOF! WOOF!"
+      dog.singleton_methods
+      # => [:barking]
+
+      cat.barking
+      # => NoMethodError (undefined method `barking' for #<Animal:0x000055a12143df38>)
+      cat.singleton_methods
+      # => []
+      ```
+
+      Методы класса (`self`-методы) на самом деле тоже являются синглтон-методами класса `Class`.
+
+      Таким образом, в Руби все методы принадлежат какому-то классу.
+
+      Синглтон-класс — это анонимный класс, в котором размещаются синглтон-методы объекта.
+
+      ```rb
+      dog.singleton_class
+      # => #<Class:#<Animal:0x000055a121433970>>
+
+      dog.singleton_class.method_defined?(:barking)
+      # => true
+
+      cat.singleton_class.method_defined?(:barking)
+      # => false
+      ```
+
+      Синглтон-класс встраивается в путь наследования и поиска метода интерпретатором Ruby.
+
+      ```rb
+      dog.singleton_class.superclass
+      # => Animal
+      ```
+
+      Подробнее [тут](https://habr.com/ru/post/143990/)
+    </details>
+
 1. Что такое `super`-методы и как они работают/где применяются?
 1. Что такое модуль в ruby? Какая разница между классом и модулем?
 


### PR DESCRIPTION
Синглтоны перенёс в Ruby
Про синглтон-классы не упомяналось в вопросе, а меня как раз про них спрашивали вчера.
На мой взгляд `say_something`, вообще, незачем было указывать. Это и так понятно, должна быть минимальная и достаточная выжимка в ответе.
Проблема с синтаксисом была (`=>`). При копировании ошибку вызовет.

Переписал без абстрактных `foo` и `bar`, чтобы наглядно было с `singleton_methods` и `singleton_class`.